### PR TITLE
Ignore composer.lock (following the best practices)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,6 @@ composer.phar
 
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
-# composer.lock
+composer.lock
 
 # End of https://www.gitignore.io/api/vim,phpstorm+iml


### PR DESCRIPTION
One of Composer's best practices is to not commit the lock file if it's a library