### PR TITLE
add intermedia span type and make it the default type

### DIFF
--- a/src/Instana/OpenTracing/InstanaSpan.php
+++ b/src/Instana/OpenTracing/InstanaSpan.php
@@ -166,6 +166,9 @@ abstract class InstanaSpan implements Span, JsonSerializable
                     case \OpenTracing\Tags\SPAN_KIND_MESSAGE_BUS_PRODUCER:
 			            $this->spanType = InstanaSpanType::exitType();
                         break;
+                    default:
+                        $this->spanType = InstanaSpanType::intermediateType();
+                        break;
                 }
                 break;
             default:

--- a/src/Instana/OpenTracing/InstanaSpanType.php
+++ b/src/Instana/OpenTracing/InstanaSpanType.php
@@ -20,6 +20,11 @@ class InstanaSpanType
     private static $local;
 
     /**
+     * @var InstanaSpanType
+     */
+    private static $intermediate;
+
+    /**
      * @var int
      */
     private $kind;
@@ -67,6 +72,16 @@ class InstanaSpanType
             self::$local = new InstanaSpanType(3, 'local');
         }
         return self::$local;
+    }
+
+    /**
+     * @return InstanaSpanType
+     */
+    public static function intermediateType() {
+        if (self::$intermediate == null) {
+            self::$intermediate = new InstanaSpanType(3, 'intermediate');
+        }
+        return self::$intermediate;
     }
 
     /**


### PR DESCRIPTION
The default span type should be intermediate
Added intermediate type to SpanType and made it the default when setting the span.kind.

Not sure if it should be the default when a span is created to be possibly overwritten later?