### PR TITLE
Add basic support for handing the context over SQS

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.json') }}
         restore-keys: |
           ${{ runner.os }}-php-
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A PHP implementation of the OpenTracing interfaces for usage with Instana.
 
 ## Requirements
 
-Requires an Instana Agent running at the configured  InstanaSpanFlusher  endpoint. By default, 
+Requires an Instana Agent running at the configured  InstanaSpanFlusher  endpoint. By default,
 traces will be sent to the PHP sensor's trace acceptor listening on port 16816 on any network
-interface on the host machine. If no PHP sensor is running on the machine receiving the traces, 
+interface on the host machine. If no PHP sensor is running on the machine receiving the traces,
 consider using the alternative REST SDK endpoint. To do so, set the global tracers as follows:
 
 ```php
@@ -14,17 +14,17 @@ use Instana\OpenTracing\InstanaTracer;
 
 \OpenTracing\GlobalTracer::set(InstanaTracer::restSdk());
 ```
-        
+
 Using the restSdk tracer will send traces to the endpoint in the agent listening on port 42699.
 
-Starting with v2.0.0 the minimum PHP version required is PHP 5.4.  
+Starting with v2.0.0 the minimum PHP version required is PHP 5.4.
 The 1.x branch will only work on PHP 7+.
 
 ## BC breaks between the 1.x version and the 2.x version
 
-The methods `InstanaSpanType::entry()`, `InstanaSpanType::local()` and `InstanaSpanType::exit()` 
-have been renamed to `InstanaSpanType::entryType()`, `InstanaSpanType::localType()` and 
-`InstanaSpanType::exitType()` to provide compatibility with PHP < 7. Direct invocations of these 
+The methods `InstanaSpanType::entry()`, `InstanaSpanType::local()` and `InstanaSpanType::exit()`
+have been renamed to `InstanaSpanType::entryType()`, `InstanaSpanType::localType()` and
+`InstanaSpanType::exitType()` to provide compatibility with PHP < 7. Direct invocations of these
 methods in your code will need to be renamed.
 
 ## Installation
@@ -44,7 +44,7 @@ You can include it manually in your composer.json like this:
     }
 }
 ```
-    
+
 Because OpenTracing v1.0.0 is still in beta, you will also need to set
 
 ```json
@@ -90,7 +90,7 @@ $parentScope->close();
 
 \OpenTracing\GlobalTracer::get()->flush();
 ```
- 
+
 ## Containerized applications
 
 When instrumenting a containerized app, you will need to provide the endpointURI to point to the
@@ -111,15 +111,25 @@ InstanaTracer::restSdk('http://172.17.0.1:42699/com.instana.plugin.generic.trace
 ```
 
 Adjust the URI to whatever URI allows communication from the container to the host.
-                
+
+## Support for 3rd party libraries
+
+### AWS SQS (Simple Queue Service) context injection and extraction
+
+When using `aws/aws-sdk-php` in your application, you will probably want to connect the dots.
+
+The shipped class `\Instana\OpenTracing\Support\SQS` enables you to inject the current context
+into the raw message passed to `\Aws\Sqs\SqsClient::sendMessage()` and extract it from messages
+received via `\Aws\Sqs\SqsClient::receiveMessage()`.
+
 ## License
 
 This library is licensed under the [MIT License](https://opensource.org/licenses/MIT)
 
 > Copyright 2018 Instana, Inc
->  
+>
 >  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->  
+>
 >  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->  
+>
 >  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ if (!empty($result->get('Messages'))) {
 }
 ```
 
+Or even easier:
+
+```php
+use Instana\OpenTracing\Support\SQS;
+
+$message = []; // receive your raw message from SQS
+$scope = SQS::enterWithMessage($message, function() use($myOtherService) {
+    // work the message as you like
+    $myOtherService->work($message);
+});
+```
+
 ## License
 
 This library is licensed under the [MIT License](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ The shipped class `\Instana\OpenTracing\Support\SQS` enables you to inject the c
 into the raw message passed to `\Aws\Sqs\SqsClient::sendMessage()` and extract it from messages
 received via `\Aws\Sqs\SqsClient::receiveMessage()`.
 
+To wrap the `sendMessage` command, call `SQS::sendMessage`:
+
+```php
+use Instana\OpenTracing\Support\SQS;
+
+SQS::sendMessage($sqsClient, $message);
+```
+
+To wrap the `sendMessageAsync` command, call `SQS::sendMessageAsync`:
+
+```php
+use Instana\OpenTracing\Support\SQS;
+
+SQS::sendMessageAsync($sqsClient, $message);
+```
+
 ## License
 
 This library is licensed under the [MIT License](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Or even easier:
 use Instana\OpenTracing\Support\SQS;
 
 $message = []; // receive your raw message from SQS
-$scope = SQS::enterWithMessage($message, function() use($myOtherService) {
+$scope = SQS::enterWithMessage($message, function($message) use($myOtherService) {
     // work the message as you like
     $myOtherService->work($message);
 });

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   "require": {
     "php": "^7.1",
     "ext-json": "*",
+    "aws/aws-sdk-php": "^3.155",
     "opentracing/opentracing": "^1@beta",
     "paragonie/random_compat": "<9.99"
   },
@@ -38,7 +39,8 @@
     "phake/phake": "^3.0"
   },
   "suggest": {
-    "ext-posix": "To be able to retrieve the process id more efficiently"
+    "ext-posix": "To be able to retrieve the process id more efficiently",
+    "aws/aws-sdk-php": "To be able to automatically wrap SQS transactions in a span"
   },
   "scripts": {
     "test": "vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,12 @@
   "autoload": {
     "files": ["./src/Instana/OpenTracing/InstanaTags.php"],
     "psr-4": {
-      "": "src/"
+      "Instana\\OpenTracing\\": "src/Instana/OpenTracing"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Instana\\OpenTracing\\": "test/Instana/OpenTracing"
     }
   },
   "require": {
@@ -34,5 +39,8 @@
   },
   "suggest": {
     "ext-posix": "To be able to retrieve the process id more efficiently"
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit"
   }
 }

--- a/src/Instana/OpenTracing/Support/SQS.php
+++ b/src/Instana/OpenTracing/Support/SQS.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Instana\OpenTracing\Support;
+
+use OpenTracing\Exceptions\UnsupportedFormat;
+use OpenTracing\SpanContext;
+use OpenTracing\Tracer;
+use OpenTracing\Formats;
+
+/**
+ * Facilitates tracing support for Amazon Simple Queue Service.
+ *
+ * We need to inject the context into our message before sending it to SQS
+ * and after receiving the message, we need to extract the context from the message.
+ */
+class SQS {
+    /**
+     * Inject the current trace context into a message that will be queued on SQS.
+     *
+     * @param Tracer $tracer The tracer to do the extraction
+     * @param SpanContext $context
+     * @param array $message The raw message
+     *
+     * @return void
+     */
+    public static function injectContext(Tracer $tracer, SpanContext $context, array &$message)
+    {
+        if (!isset($message['MessageAttributes']['Instana'])) {
+            $message['MessageAttributes']['Instana'] = [
+                'DataType' => 'String',
+                'StringValue' => '',
+            ];
+        }
+
+        $carrier = [];
+        $tracer->inject($context, Formats\TEXT_MAP, $carrier);
+        $message['MessageAttributes']['Instana']['StringValue'] = \json_encode($carrier);
+    }
+
+    /**
+     * Extract the span context from the message read from the queue.
+     *
+     * @param Tracer $tracer
+     * @param array $message
+     * @return null|SpanContext
+     * @throws UnsupportedFormat
+     */
+    public static function extractContext(Tracer $tracer, array $message): ?SpanContext
+    {
+        if (!isset($message['MessageAttributes']['Instana'])) {
+            return null;
+        }
+
+        if (!isset($message['MessageAttributes']['Instana']['StringValue'])) {
+            return null;
+        }
+
+        $carrier = \json_decode($message['MessageAttributes']['Instana']['StringValue'], true);
+
+        return $tracer->extract(Formats\TEXT_MAP, $carrier);
+    }
+}

--- a/src/Instana/OpenTracing/Support/SQS.php
+++ b/src/Instana/OpenTracing/Support/SQS.php
@@ -83,7 +83,7 @@ class SQS {
 
         $span->setTag(Tags\SPAN_KIND, Tags\SPAN_KIND_MESSAGE_BUS_PRODUCER);
 
-        $span->setTag('message_bus.destination', $queueUrl);
+        $span->setTag(Tags\MESSAGE_BUS_DESTINATION, $queueUrl);
 
         $span->setTag('messaging.type', 'sqs');
         $span->setTag('messaging.address', $queueUrl);

--- a/src/Instana/OpenTracing/Support/SQS.php
+++ b/src/Instana/OpenTracing/Support/SQS.php
@@ -47,9 +47,6 @@ class SQS {
         $span->setTag('messaging.exchangeType', 'SQS');
         $span->setTag('messaging.routingKey', $queueUrl);
 
-        $span->setTag('sqs.queue', $queueUrl);
-        $span->setTag('sqs.sort', 'exit');
-
         // inject ourselves into the message
         self::injectContext($tracer, $span->getContext(), $message);
 

--- a/test/Instana/OpenTracing/InstanaHttpSpanFlusherTest.php
+++ b/test/Instana/OpenTracing/InstanaHttpSpanFlusherTest.php
@@ -2,8 +2,6 @@
 
 namespace Instana\OpenTracing;
 
-include_once 'HttpMockServer.php';
-
 use PHPUnit\Framework\TestCase;
 
 class InstanaHttpSpanFlusherTest extends TestCase
@@ -31,7 +29,7 @@ class InstanaHttpSpanFlusherTest extends TestCase
         self::$outfile = tempnam(sys_get_temp_dir(), basename(__FILE__));
         self::$router = tempnam(sys_get_temp_dir(), basename(__FILE__));
 
-        file_put_contents(self::$router, '<?php 
+        file_put_contents(self::$router, '<?php
             $input = file_get_contents("php://input");
             $headers = getallheaders();
             $headers["data"] = "$input";

--- a/test/Instana/OpenTracing/MicrotimeTest.php
+++ b/test/Instana/OpenTracing/MicrotimeTest.php
@@ -2,7 +2,6 @@
 
 namespace Instana\OpenTracing;
 
-
 use PHPUnit\Framework\TestCase;
 
 class MicrotimeTest extends TestCase
@@ -96,5 +95,4 @@ class MicrotimeTest extends TestCase
         $this->assertTrue(strlen($microtime->getMilliseconds()) == strlen($microtime->getMicrotime()) - 3);
         $this->assertStringStartsWith($microtime->getMilliseconds(), $microtime->getMicrotime());
     }
-
 }

--- a/test/Instana/OpenTracing/NoopSpanFlusher.php
+++ b/test/Instana/OpenTracing/NoopSpanFlusher.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Instana\OpenTracing;
+
+use Instana\OpenTracing\InstanaSpanFlusher;
+
+class NoopSpanFlusher implements InstanaSpanFlusher {
+    private $spans;
+
+    public function __construct()
+    {
+        $this->spans = [];
+    }
+
+    /**
+     * Flush the given spans to an internal array.
+     *
+     * @param array $unflushedSpans
+     * @return void
+     */
+    public function flushAll(array $unflushedSpans) {
+        foreach ($unflushedSpans as $span) {
+            $this->spans[] = $span;
+        }
+    }
+
+    /**
+     * Get all the spans created.
+     *
+     * @return array
+     */
+    public function getSpans()
+    {
+        return $this->spans;
+    }
+}

--- a/test/Instana/OpenTracing/Support/SQSTest.php
+++ b/test/Instana/OpenTracing/Support/SQSTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Instana\OpenTracing\Support;
+
+use Instana\OpenTracing\InstanaSpanContext;
+use Instana\OpenTracing\InstanaTracer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @test
+ */
+class SQSTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideTracer
+     */
+    public function testInjectionAndExtraction(InstanaTracer $instanaTracer)
+    {
+        $spanContext = InstanaSpanContext::createRoot();
+        $this->assertNull($spanContext->getParentId());
+        $this->assertRegExp('#^[0-9a-f]{16}$#', $spanContext->getSpanId());
+
+        $message = [
+            'MessageAttributes' => []
+        ];
+
+        SQS::injectContext($instanaTracer, $spanContext, $message);
+
+        // check if the context was injected into the SQS message
+        $this->assertArrayHasKey('Instana', $message['MessageAttributes']);
+        $this->assertArrayHasKey('DataType', $message['MessageAttributes']['Instana']);
+        $this->assertArrayHasKey('StringValue', $message['MessageAttributes']['Instana']);
+
+        $this->assertEquals('String', $message['MessageAttributes']['Instana']['DataType']);
+        $this->assertJson($message['MessageAttributes']['Instana']['StringValue']);
+
+        $context = json_decode($message['MessageAttributes']['Instana']['StringValue'], true);
+
+        $this->assertEquals($spanContext->getSpanId(), $context['X-INSTANA-T']);
+        $this->assertEquals($spanContext->getSpanId(), $context['X-INSTANA-S']);
+        $this->assertEquals('1', $context['X-INSTANA-L']);
+
+        /** @var InstanaSpanContext */
+        $extractedContext = SQS::extractContext($instanaTracer, $message);
+
+        $this->assertInstanceOf(InstanaSpanContext::class, $extractedContext);
+
+        $this->assertEquals($spanContext->getSpanId(), $extractedContext->getSpanId());
+    }
+
+    public function provideTracer()
+    {
+        return [
+            [InstanaTracer::phpSensor()],
+            [InstanaTracer::restSdk()]
+        ];
+    }
+}


### PR DESCRIPTION
### AWS SQS (Simple Queue Service) context injection and extraction

When using `aws/aws-sdk-php` in your application, you will probably want to connect the dots.

The shipped class `\Instana\OpenTracing\Support\SQS` enables you to inject the current context
into the raw message passed to `\Aws\Sqs\SqsClient::sendMessage()` and extract it from messages
received via `\Aws\Sqs\SqsClient::receiveMessage()`.

To wrap the `sendMessage` command, call `SQS::sendMessage`:

```php
use Instana\OpenTracing\Support\SQS;

SQS::sendMessage($sqsClient, $message);
```

To wrap the `sendMessageAsync` command, call `SQS::sendMessageAsync`:

```php
use Instana\OpenTracing\Support\SQS;

SQS::sendMessageAsync($sqsClient, $message);
```

Receiving a message and continueing from there is equally easy:

```php
use Instana\OpenTracing\InstanaTags;
use Instana\OpenTracing\Support\SQS;
use OpenTracing\Tags;

$result = $sqsClient->receiveMessage([
    'AttributeNames' => ['SentTimestamp'],
    'MaxNumberOfMessages' => 1,
    'MessageAttributeNames' => ['All'],
    'QueueUrl' => $queueUrl, // REQUIRED
    'WaitTimeSeconds' => 0,
]);

if (!empty($result->get('Messages'))) {
    $message = $result->get('Messages')[0];
    $context = SQS::extractContext($tracer, $message);
    $scope = $tracer->startActiveSpan('sqs', [
        'child_of' => $context,
    ]);

    $span = $scope->getSpan();
    $span->setTag(InstanaTags\SERVICE, 'php-consumer');
    $span->setTag(Tags\SPAN_KIND, Tags\SPAN_KIND_MESSAGE_BUS_CONSUMER);
    $span->setTag(Tags\MESSAGE_BUS_DESTINATION, $queueUrl);

    // ..do your thing..

    $scope->close();
}
```

Or even easier:

```php
use Instana\OpenTracing\Support\SQS;

$message = []; // receive your raw message from SQS
$scope = SQS::enterWithMessage($message, function($message) use($myOtherService) {
    // work the message as you like
    $myOtherService->work($message);
});
```